### PR TITLE
twDataTypes: always import `warnings` to avoid NameErrors

### DIFF
--- a/src/tweety/types/twDataTypes.py
+++ b/src/tweety/types/twDataTypes.py
@@ -1,13 +1,14 @@
 import sys
+import warnings
 from dateutil import parser
 import openpyxl
 import dateutil
 
 try:
     import wget
-    import warnings
 except ModuleNotFoundError:
     warnings.warn(' "wget" not found in system ,you will not be able to download the medias')
+
 WORKBOOK_HEADERS = ['Created on', 'author', 'is_retweet', 'is_reply', 'tweet_id', 'tweet_body', 'language', 'likes',
                     'retweet_count', 'source', 'medias', 'user_mentioned', 'urls', 'hashtags', 'symbols']
 


### PR DESCRIPTION
If `import wget` raises an exception then the following `import warnings` statement will never run.

Since `warnings` is also used elsewhere in the file, moved to global imports.