### PR TITLE
Fixup `socks`: require module, fix type hint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ httpx
 openpyxl
 dateutils
 tqdm
+PySocks~=1.7.1

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(
         'openpyxl',
         'httpx',
         'dateutils',
-        'tqdm'
+        'tqdm',
+        'PySocks~=1.7.1',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/src/tweety/types/n_types.py
+++ b/src/tweety/types/n_types.py
@@ -2,11 +2,9 @@ from typing import Union
 import socks
 from ..exceptions_ import *
 
-PROXY_TYPES = Union[socks.SOCKS4, socks.SOCKS5, socks.HTTP]
-
 
 class Proxy:
-    def __init__(self, host: str, port: int, proxy_type: PROXY_TYPES, username: str = None, password: str = None):
+    def __init__(self, host: str, port: int, proxy_type: int, username: str = None, password: str = None):
         self.host = host
         self.password = password
         self.proxy_type = proxy_type


### PR DESCRIPTION
`socks` is not part of the standard library. A web search to find `PySocks` plus a quick inspection of its documentation indicated this is probably the module that was intended to be required. (At least, this changeset got me far enough along to where my own code written for the previous `tweety` version caused an error, instead of `tweety` itself. 😅)

Can't pass module attributes directly to a `Union[]`; they are passed as values, not types. Since PySocks is constrained to a very narrow version range (and hasn't seen an update since 2019 anyway), using the type (`int`) directly shouldn't be an issue.