### PR TITLE
Fix: search result pagination with cursor

### DIFF
--- a/src/tweety/types/search.py
+++ b/src/tweety/types/search.py
@@ -39,11 +39,14 @@ class Search(dict):
     @staticmethod
     def _get_entries(response):
         instructions = response['data']['search_by_raw_query']['search_timeline']['timeline']['instructions']
+        entries = []
         for instruction in instructions:
             if instruction.get("type") == "TimelineAddEntries":
-                return instruction['entries']
+                entries.extend(instruction['entries'])
+            elif instruction.get("type") == "TimelineReplaceEntry":
+                entries.append(instruction['entry'])
 
-        return []
+        return entries
 
     @staticmethod
     def _get_tweet_content_key(response):


### PR DESCRIPTION
Fix for a regression issue #26

Twitter has changed the way of returning cursor for search results.

For the first request, it is part of the `TimelineAddEntries` (which is handled in the current implementation)
![initial](https://github.com/mahrtayyab/tweety/assets/15910378/b62139aa-a4e9-4545-8515-f5433e64a18d)

From the next request, there are additional entries "TimelineReplaceEntry" which contains the Top and the Bottom cursor.
![new](https://github.com/mahrtayyab/tweety/assets/15910378/ca868b13-4fc4-4be4-874c-6baf1aaa4ac8)

This PR handles these additional entries in the `_get_entries` function and enables cursor pagination according to latest response.