### PR TITLE
Reply flag on create_tweet method + typo in docs

### DIFF
--- a/docs/basic/all-functions.rst
+++ b/docs/basic/all-functions.rst
@@ -540,7 +540,7 @@ Sending Message
 Creating a Tweet
 ---------------------
 
-- .. py:method:: Twitter().create_tweet(text: str, files: list[Union[str, UploadedMedia, tuple[str, str]]] = None, filter_: str = None)
+- .. py:method:: Twitter().create_tweet(text: str, files: list[Union[str, UploadedMedia, tuple[str, str]]] = None, filter_: str = None, reply: str = None)
 
     Create a Tweet using the authenticated user
 
@@ -561,6 +561,11 @@ Creating a Tweet
 
            Filter to be applied for Tweet Audience. More about :ref:`filter`
 
+        .. py:data:: reply
+            :type: str
+
+            ID of tweet to reply to
+
 
     .. py:data:: Return
 
@@ -572,6 +577,6 @@ Creating a Tweet
        from tweety.bot import Twitter
 
        app = Twitter("session")
-       message = app.send_message("user", "Hi")
+       message = app.create_tweet("user", reply="1690430294208483322")
 
 

--- a/src/tweety/builder.py
+++ b/src/tweety/builder.py
@@ -548,7 +548,7 @@ class UrlBuilder:
         return "POST", self._build(self.URL_AUSER_SEND_MESSAGE, urlencode(params)), json_data
 
     @return_with_headers
-    def create_tweet(self, text, files, filter_=None):
+    def create_tweet(self, text, files, filter_=None, reply=None):
         media_entities = utils.create_media_entities(files)
         variables = {
             'tweet_text': text,
@@ -559,6 +559,12 @@ class UrlBuilder:
             },
             'semantic_annotation_ids': []
         }
+
+        if reply:
+            variables['reply'] = {
+                'exclude_reply_user_ids': [],
+                'in_reply_to_tweet_id': reply
+            }
 
         features = {
             'tweetypie_unmention_optimization_enabled': True,

--- a/src/tweety/http.py
+++ b/src/tweety/http.py
@@ -151,8 +151,8 @@ class Request:
         response = self.__get_response__(**request_data)
         return response
 
-    def create_tweet(self, text, files, filter_):
-        request_data = self.__builder.create_tweet(text, files, filter_)
+    def create_tweet(self, text, files, filter_, reply):
+        request_data = self.__builder.create_tweet(text, files, filter_, reply)
         response = self.__get_response__(**request_data)
         return response
 

--- a/src/tweety/user.py
+++ b/src/tweety/user.py
@@ -152,7 +152,8 @@ class UserMethods:
             self,
             text: str,
             files: list[Union[str, UploadedMedia, tuple[str, str]]] = None,
-            filter_: str = None
+            filter_: str = None,
+            reply: str = None
     ) -> Tweet:
 
         """
@@ -161,6 +162,7 @@ class UserMethods:
         :param text: (`str`) Text content of Tweet
         :param files: (`list[Union[str, UploadedMedia, tuple[str, str]]]`) Files to be sent with Tweet (max 4)
         :param filter_: (`str`) Filter to applied for Tweet audience
+        :param reply: (`str`) ID of tweet to reply to
         :return: Tweet
         """
 
@@ -169,7 +171,7 @@ class UserMethods:
         else:
             files = []
 
-        response = self.request.create_tweet(text, files, filter_)
+        response = self.request.create_tweet(text, files, filter_, reply)
         return Tweet(response['data']['create_tweet']['tweet_results']['result'], self.request, response)
 
     def _upload_media(self, files, _type="tweet_image"):


### PR DESCRIPTION
Added support for replying to tweets by passing a parent tweet ID in the 'reply' flag of the create_tweet method + updated docs to reflect this change. Also fixed typo in docs (Create Tweet section was calling send_message method)