### PR TITLE
Various data parsing fixes

### DIFF
--- a/src/tweety/bot.py
+++ b/src/tweety/bot.py
@@ -232,8 +232,7 @@ class BotMethods:
                     if raw_tweet.get('tweet'):
                         raw_tweet = raw_tweet['tweet']
                     
-                    if raw_tweet['rest_id'] == str(tweetId):
+                    if raw_tweet.get('rest_id') == str(tweetId):
                         return Tweet(raw_tweet, self.request, r)
-
         except KeyError:
             raise InvalidTweetIdentifier(144, "StatusNotFound", r)

--- a/src/tweety/bot.py
+++ b/src/tweety/bot.py
@@ -229,7 +229,9 @@ class BotMethods:
             for entry in r['data']['threaded_conversation_with_injections_v2']['instructions'][0]['entries']:
                 if str(entry['entryId']).split("-")[0] == "tweet":
                     raw_tweet = entry['content']['itemContent']['tweet_results']['result']
-
+                    if 'tweet' in raw_tweet:
+                        raw_tweet = raw_tweet['tweet']
+                    
                     if raw_tweet['rest_id'] == str(tweetId):
                         return Tweet(raw_tweet, self.request, r)
 

--- a/src/tweety/bot.py
+++ b/src/tweety/bot.py
@@ -229,7 +229,7 @@ class BotMethods:
             for entry in r['data']['threaded_conversation_with_injections_v2']['instructions'][0]['entries']:
                 if str(entry['entryId']).split("-")[0] == "tweet":
                     raw_tweet = entry['content']['itemContent']['tweet_results']['result']
-                    if 'tweet' in raw_tweet:
+                    if raw_tweet.get('tweet'):
                         raw_tweet = raw_tweet['tweet']
                     
                     if raw_tweet['rest_id'] == str(tweetId):

--- a/src/tweety/types/twDataTypes.py
+++ b/src/tweety/types/twDataTypes.py
@@ -346,8 +346,8 @@ class Tweet(dict):
 
     @staticmethod
     def _is_retweet(original_tweet):
-        if original_tweet.get("retweeted"):
-            return True
+        if 'retweeted' in original_tweet:
+            return original_tweet['retweeted']
 
         if str(original_tweet.get('full_text', "")).startswith("RT"):
             return True

--- a/src/tweety/types/twDataTypes.py
+++ b/src/tweety/types/twDataTypes.py
@@ -166,6 +166,7 @@ class Tweet(dict):
 
     def _format_tweet(self):
         original_tweet = self.__tweet['legacy'] if self.__tweet.get('legacy') else self.__tweet
+        self._original_tweet = original_tweet
         self.id = self._get_id()
         self.created_on = self.date = self._get_date(original_tweet)
         self.author = self._get_author()
@@ -315,10 +316,20 @@ class Tweet(dict):
                 response = self.http.get_tweet_detail(tweet_id)
             else:
                 response = self.__full_response
-            for entry in response['data']['threaded_conversation_with_injections_v2']['instructions'][0]['entries']:
-                if str(entry['entryId']).split("-")[0] == "tweet" and str(entry['content']['itemContent']['tweet_results']['result']['rest_id']) == str(tweet_id):
-                    raw_tweet = entry['content']['itemContent']['tweet_results']['result']
-                    return Tweet(raw_tweet, self.http)
+
+            try:
+                if 'threaded_conversation_with_injections_v2' in response['data']:
+                    entries = response['data']['threaded_conversation_with_injections_v2']['instructions'][0]['entries']
+                else:
+                    entries = response['data']['search_by_raw_query']['search_timeline']['timeline']['instructions'][0]['entries']
+                
+                for entry in entries:
+                    if str(entry['entryId']).split("-")[0] == "tweet" and str(entry['content']['itemContent']['tweet_results']['result']['rest_id']) == str(tweet_id):
+                        raw_tweet = entry['content']['itemContent']['tweet_results']['result']
+                        return Tweet(raw_tweet, self.http)
+            except:
+                pass
+
         return None
 
     @staticmethod
@@ -347,7 +358,7 @@ class Tweet(dict):
     def _is_reply(original_tweet):
         tweet_keys = list(original_tweet.keys())
         required_keys = ["in_reply_to_status_id_str", "in_reply_to_user_id_str", "in_reply_to_screen_name"]
-        return any(x in tweet_keys and original_tweet[x] is True for x in required_keys)
+        return any(x in tweet_keys for x in required_keys)
 
     @staticmethod
     def _is_quoted(original_tweet):

--- a/src/tweety/types/twDataTypes.py
+++ b/src/tweety/types/twDataTypes.py
@@ -166,7 +166,7 @@ class Tweet(dict):
 
     def _format_tweet(self):
         original_tweet = self.__tweet['legacy'] if self.__tweet.get('legacy') else self.__tweet
-        self._original_tweet = original_tweet
+        self.original_tweet = original_tweet
         self.id = self._get_id()
         self.created_on = self.date = self._get_date(original_tweet)
         self.author = self._get_author()
@@ -311,14 +311,14 @@ class Tweet(dict):
 
     def _get_reply_to(self, is_reply):
         if is_reply:
-            tweet_id = self.__tweet['legacy']['in_reply_to_status_id_str']
+            tweet_id = self.original_tweet['in_reply_to_status_id_str']
             if not self.__full_response:
                 response = self.http.get_tweet_detail(tweet_id)
             else:
                 response = self.__full_response
 
             try:
-                if 'threaded_conversation_with_injections_v2' in response['data']:
+                if response['data'].get('threaded_conversation_with_injections_v2'):
                     entries = response['data']['threaded_conversation_with_injections_v2']['instructions'][0]['entries']
                 else:
                     entries = response['data']['search_by_raw_query']['search_timeline']['timeline']['instructions'][0]['entries']
@@ -358,7 +358,7 @@ class Tweet(dict):
     def _is_reply(original_tweet):
         tweet_keys = list(original_tweet.keys())
         required_keys = ["in_reply_to_status_id_str", "in_reply_to_user_id_str", "in_reply_to_screen_name"]
-        return any(x in tweet_keys for x in required_keys)
+        return all(x in tweet_keys for x in required_keys)
 
     @staticmethod
     def _is_quoted(original_tweet):


### PR DESCRIPTION
My effort to try and get just a bit more of the API working as much as I can, at least the parts I need [for my own project](https://github.com/muskit/NijiHolo_EN_ID_Bot) which focuses on various Tweet and user relationships.

- Add various path-checks for different types of responses (fixes #65)
- `Tweet._is_reply` will only check for existence of reply-related keys, preventing false negative (partially fixes #33; there's still no http call to retrieve the tweet if it's missing)
- Add `Tweet.original_tweet` to allow picking up of any desired missing info (ie. replied tweet's ID if it never gets pulled in Search; works as a workaround for #33)
- Fix `Tweet._is_retweet` logic

# NOTE: DOCUMENTATION NEEDED (`Tweet.original_tweet`)