### PR TITLE
Require BeautifulSoup ~= 4.12 with lxml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     url='https://github.com/mahrtayyab/tweety',
     keywords=['TWITTER', 'TWITTER SCRAPE', 'SCRAPE TWEETS'],
     install_requires=[
-        'beautifulsoup4',
+        'beautifulsoup4[lxml]~=4.12',
         'openpyxl',
         'httpx[http2]',
         'dateutils',


### PR DESCRIPTION
bs4 4.12 still supports Python versions back to 3.6, so it's safe to require the 'latest' branch (4.13 is still in beta).

The `lxml` extra co-installs the lxml parser, which tweety uses in some places (and without it, raises exceptions).

Resolves #224