### PR TITLE
fix: remove `httpx`'s deprecated parameter `proxies`

### DIFF
--- a/src/tweety/bot.py
+++ b/src/tweety/bot.py
@@ -20,7 +20,7 @@ class BotMethods:
         Constructor of the Twitter Public class
 
         :param: session_name: (`str`, `Session`) This is the name of the session which will be saved and can be loaded later
-        :param: proxy: (`dict` or `Proxy`) Provide the proxy you want to use while making a request
+        :param: proxy: [DEPRECATED] (`dict` or `Proxy`) Provide the proxy you want to use while making a request
         :param: captcha_solver: (`BaseCaptchaSolver`) Provide the instance of captcha solver class
                                 which has two mandatory methods named `unlock`, `__call__`.
                                 - both mandatory methods should accept at least one argument
@@ -50,6 +50,9 @@ class BotMethods:
                 raise AttributeError("captcha_solver instance '{}' doesn't have 'unlock' method".format(type(captcha_solver)))
             elif "__call__" not in dir(captcha_solver):
                 raise AttributeError("captcha_solver instance '{}' doesn't have '__call__' method".format(type(captcha_solver)))
+
+        if self._proxy is not None:
+            raise ValueError("`proxy` parameter has already been deprecated")
 
             # Captcha Solver is broken
             # self._captcha_solver = captcha_solver(self, self._proxy)

--- a/src/tweety/bot.py
+++ b/src/tweety/bot.py
@@ -1,6 +1,8 @@
 import warnings
 from typing import Union, Type
 from httpx._types import ProxyTypes
+from httpx._config import Proxy as httpxProxy
+from httpx._urls import URL
 from .utils import (find_objects, AuthRequired, get_user_from_typehead, get_tweet_id, check_translation_lang,
                     is_tweet_protected, async_list)
 from .types import (Proxy, TweetComments, UserTweets, Search, User, Tweet, Trends, Community, CommunityTweets,
@@ -16,7 +18,7 @@ from .captcha.base import BaseCaptchaSolver
 class BotMethods:
     LOGIN_URL = "https://api.x.com/1.1/onboarding/task.json?flow_name=login"
 
-    def __init__(self, session_name: Union[str, Session], proxy: ProxyTypes | None = None, captcha_solver: Type[BaseCaptchaSolver] = None, **httpx_kwargs):
+    def __init__(self, session_name: Union[str, Session], proxy: Union[ProxyTypes, None] = None, captcha_solver: Type[BaseCaptchaSolver] = None, **httpx_kwargs):
         """
         Constructor of the Twitter Public class
 
@@ -45,8 +47,13 @@ class BotMethods:
             self.session = session_name
         else:
             self.session = FileSession(self, session_name)
-        if not (isinstance(proxy, ProxyTypes) or proxy is None):
-            raise ValueError("'proxy' argument must be ProxyTypes or None")
+        if not (
+                isinstance(proxy, URL) or \
+                isinstance(proxy, str) or \
+                isinstance(proxy, httpxProxy) or \
+                proxy is None
+            ):
+            raise ValueError("'proxy' argument must be ProxyTypes(URL | str | Proxy) or None")
 
         if captcha_solver:
             if not hasattr(captcha_solver, "unlock"):

--- a/src/tweety/bot.py
+++ b/src/tweety/bot.py
@@ -20,7 +20,7 @@ class BotMethods:
         Constructor of the Twitter Public class
 
         :param: session_name: (`str`, `Session`) This is the name of the session which will be saved and can be loaded later
-        :param: proxy: [DEPRECATED] (`dict` or `Proxy`) Provide the proxy you want to use while making a request
+        :param: proxy: (`dict` or `Proxy`) Provide the proxy you want to use while making a request
         :param: captcha_solver: (`BaseCaptchaSolver`) Provide the instance of captcha solver class
                                 which has two mandatory methods named `unlock`, `__call__`.
                                 - both mandatory methods should accept at least one argument
@@ -50,9 +50,6 @@ class BotMethods:
                 raise AttributeError("captcha_solver instance '{}' doesn't have 'unlock' method".format(type(captcha_solver)))
             elif "__call__" not in dir(captcha_solver):
                 raise AttributeError("captcha_solver instance '{}' doesn't have '__call__' method".format(type(captcha_solver)))
-
-        if self._proxy is not None:
-            raise ValueError("`proxy` parameter has already been deprecated")
 
             # Captcha Solver is broken
             # self._captcha_solver = captcha_solver(self, self._proxy)

--- a/src/tweety/bot.py
+++ b/src/tweety/bot.py
@@ -1,5 +1,6 @@
 import warnings
 from typing import Union, Type
+from httpx._types import ProxyTypes
 from .utils import (find_objects, AuthRequired, get_user_from_typehead, get_tweet_id, check_translation_lang,
                     is_tweet_protected, async_list)
 from .types import (Proxy, TweetComments, UserTweets, Search, User, Tweet, Trends, Community, CommunityTweets,
@@ -15,12 +16,12 @@ from .captcha.base import BaseCaptchaSolver
 class BotMethods:
     LOGIN_URL = "https://api.x.com/1.1/onboarding/task.json?flow_name=login"
 
-    def __init__(self, session_name: Union[str, Session], proxy: Union[dict, Proxy] = None, captcha_solver: Type[BaseCaptchaSolver] = None, **httpx_kwargs):
+    def __init__(self, session_name: Union[str, Session], proxy: ProxyTypes | None = None, captcha_solver: Type[BaseCaptchaSolver] = None, **httpx_kwargs):
         """
         Constructor of the Twitter Public class
 
         :param: session_name: (`str`, `Session`) This is the name of the session which will be saved and can be loaded later
-        :param: proxy: (`dict` or `Proxy`) Provide the proxy you want to use while making a request
+        :param: proxy: (`ProxyTypes` or `None`) Provide the proxy you want to use while making a request
         :param: captcha_solver: (`BaseCaptchaSolver`) Provide the instance of captcha solver class
                                 which has two mandatory methods named `unlock`, `__call__`.
                                 - both mandatory methods should accept at least one argument
@@ -34,7 +35,7 @@ class BotMethods:
         self._login_flow_state = None
         self._last_json = {}
         self._cached_users = {}
-        self._proxy = proxy.get_dict() if isinstance(proxy, Proxy) else proxy
+        self._proxy = proxy
         self._event_builders = []
         self._captcha_solver = None
 
@@ -44,6 +45,8 @@ class BotMethods:
             self.session = session_name
         else:
             self.session = FileSession(self, session_name)
+        if not (isinstance(proxy, ProxyTypes) or proxy is None):
+            raise ValueError("'proxy' argument must be ProxyTypes or None")
 
         if captcha_solver:
             if not hasattr(captcha_solver, "unlock"):

--- a/src/tweety/http.py
+++ b/src/tweety/http.py
@@ -25,6 +25,8 @@ class Request:
     def __init__(self, client, max_retries=3, proxy=None, captcha_solver=None, **kwargs):
 
         timeout = kwargs.pop("timeout", 60)
+        if proxy is not None:
+            raise ValueError("`proxy` parameter has already been deprecated")
 
         self.user = None
         self.username = None
@@ -42,7 +44,6 @@ class Request:
                 'origin': 'https://x.com'
             },
             http2=True,
-            proxies=proxy,
             timeout=timeout,
             follow_redirects=True,
             **kwargs

--- a/src/tweety/http.py
+++ b/src/tweety/http.py
@@ -9,7 +9,6 @@ from typing import Callable
 from urllib.parse import quote, urlparse
 import bs4
 import httpx
-from httpx._types import ProxyTypes
 from .exceptions import GuestTokenNotFound, TwitterError, UserNotFound, InvalidCredentials
 from .types import User
 from .types.n_types import GenericError
@@ -23,9 +22,7 @@ httpx.Response.json = custom_json
 
 class Request:
 
-    def __init__(self, client, max_retries=3, proxy: ProxyTypes | None=None, captcha_solver=None, **kwargs):
-        if not (isinstance(proxy, ProxyTypes) or ProxyTypes is None):
-            raise ValueError("'proxy' argument must be ProxyTypes or None")
+    def __init__(self, client, max_retries=3, proxy=None, captcha_solver=None, **kwargs):
 
         timeout = kwargs.pop("timeout", 60)
 

--- a/src/tweety/http.py
+++ b/src/tweety/http.py
@@ -9,6 +9,7 @@ from typing import Callable
 from urllib.parse import quote, urlparse
 import bs4
 import httpx
+from httpx._types import ProxyTypes
 from .exceptions import GuestTokenNotFound, TwitterError, UserNotFound, InvalidCredentials
 from .types import User
 from .types.n_types import GenericError
@@ -22,7 +23,9 @@ httpx.Response.json = custom_json
 
 class Request:
 
-    def __init__(self, client, max_retries=3, proxy=None, captcha_solver=None, **kwargs):
+    def __init__(self, client, max_retries=3, proxy: ProxyTypes | None=None, captcha_solver=None, **kwargs):
+        if not (isinstance(proxy, ProxyTypes) or ProxyTypes is None):
+            raise ValueError("'proxy' argument must be ProxyTypes or None")
 
         timeout = kwargs.pop("timeout", 60)
 

--- a/src/tweety/http.py
+++ b/src/tweety/http.py
@@ -42,7 +42,7 @@ class Request:
                 'origin': 'https://x.com'
             },
             http2=True,
-            proxies=proxy,
+            proxy=proxy,
             timeout=timeout,
             follow_redirects=True,
             **kwargs

--- a/src/tweety/http.py
+++ b/src/tweety/http.py
@@ -25,8 +25,6 @@ class Request:
     def __init__(self, client, max_retries=3, proxy=None, captcha_solver=None, **kwargs):
 
         timeout = kwargs.pop("timeout", 60)
-        if proxy is not None:
-            raise ValueError("`proxy` parameter has already been deprecated")
 
         self.user = None
         self.username = None
@@ -44,6 +42,7 @@ class Request:
                 'origin': 'https://x.com'
             },
             http2=True,
+            proxies=proxy,
             timeout=timeout,
             follow_redirects=True,
             **kwargs


### PR DESCRIPTION
Fix https://github.com/mahrtayyab/tweety/issues/230:

I can't find any usecase / demo with `proxies` parameter from [docs](https://mahrtayyab.github.io/tweety_docs/index.html), and it has already deprecated [httpx](https://github.com/encode/httpx/releases/tag/0.28.0). I think it's time to remove it from project.

