### PR TITLE
Make Python 3.9+ requirement explicit

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ classifiers =
 package_dir =
     = src
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.9
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Barring work on #78, tweety cannot be used on python versions below 3.9. This makes that version requirement explicit.