### PR TITLE
add disclaimer for Search settings

### DIFF
--- a/docs/basic/all-functions.rst
+++ b/docs/basic/all-functions.rst
@@ -230,6 +230,10 @@ Searching a Keyword
 
     Search for a keyword or hashtag on Twitter (`iter` for generator)
 
+    Disclaimer: Some sensitive results may be hidden by your account's search settings.
+    To view all results, disable *Hide sensitive content* and *Remove blocked and muted accounts* in
+   `https://x.com/settings/content_you_see`.
+
     .. py:data:: Arguments
 
         .. py:data:: keyword (Required)

--- a/docs/basic/all-functions.rst
+++ b/docs/basic/all-functions.rst
@@ -232,7 +232,7 @@ Searching a Keyword
 
     Disclaimer: Some sensitive results may be hidden by your account's search settings.
     To view all results, disable *Hide sensitive content* and *Remove blocked and muted accounts* in
-   `https://x.com/settings/content_you_see`.
+   `https://x.com/settings/search`.
 
     .. py:data:: Arguments
 


### PR DESCRIPTION
Hey I noticed that it was mentioned in #120 that `Hide sensitive content` is set disabled by default. But  I had to actually manually disable it in the search settings (https://x.com/settings/search) myself before I got any results. So I decided to add a disclaimer in the docs.
