### PR TITLE
Fix profile image URL handling for new Twitter/X API structure

### DIFF
--- a/src/tweety/types/twDataTypes.py
+++ b/src/tweety/types/twDataTypes.py
@@ -1377,7 +1377,15 @@ class User(_TwType):
         self.normal_followers_count = self._original_user.get("normal_followers_count", 0)
         self.subscriptions_count = self._user.get("creator_subscriptions_count", 0)
         self.profile_banner_url = self._original_user.get("profile_banner_url")
-        self.profile_image_url_https = self.profile_image_url = self._original_user.get("profile_image_url_https")
+        # Twitter/X has changed API structure - profile images are now in avatar.image_url
+        # Try new structure first, then fallback to old structure
+        avatar_image_url = self._user.get("avatar", {}).get("image_url")
+        profile_image_url_https = self._original_user.get("profile_image_url_https")
+        profile_image_url = self._original_user.get("profile_image_url")
+        
+        # Use new avatar URL if available, otherwise fallback to old structure
+        self.profile_image_url_https = avatar_image_url or profile_image_url_https or profile_image_url
+        self.profile_image_url = avatar_image_url or profile_image_url or profile_image_url_https
         self.profile_interstitial_type = self._original_user.get("profile_interstitial_type")
         self.protected = self._user.get("privacy", {}).get("protected", False)
         self.screen_name = self.username = self._original_user.get("screen_name") or self._core.get("screen_name")


### PR DESCRIPTION
- Handle new avatar.image_url structure in User class
- Add fallback to legacy profile_image_url_https and profile_image_url
- Ensures compatibility with both old and new API responses