### PR TITLE
fix: migrate SearchTimeline from GET to POST

### DIFF
--- a/src/tweety/builder.py
+++ b/src/tweety/builder.py
@@ -21,7 +21,7 @@ class UrlBuilder:
     URL_USER_LIKES = "https://x.com/i/api/graphql/32OdaXdMRRC5hslSEJYFdQ/Likes"
     URL_USER_TWEETS_WITH_REPLIES = "https://x.com/i/api/graphql/Z9gIrY5Gq-2K7HXhIimlyQ/UserTweetsAndReplies"
     URL_TRENDS = "https://x.com/i/api/2/guide.json"
-    URL_SEARCH = "https://x.com/i/api/graphql/nKAncKPF1fV1xltvF3UUlw/SearchTimeline"
+    URL_SEARCH = "https://x.com/i/api/graphql/GcXk9vN_d1jUfHNqLacXQA/SearchTimeline"
     URL_SEARCH_TYPEHEAD = "https://x.com/i/api/1.1/search/typeahead.json"
     URL_GIF_SEARCH = "https://x.com/i/api/1.1/foundmedia/search.json"
     URL_PLACE_SEARCH = "https://x.com/i/api/1.1/geo/places.json"
@@ -452,8 +452,12 @@ class UrlBuilder:
         if filter_:
             variables['product'] = filter_
 
-        params = {'variables': utils.json_stringify(variables), 'features': utils.json_stringify(features)}
-        return "GET", self.URL_SEARCH, urlencode(params, safe='"()%', quote_via=urllib.parse.quote_plus)
+        body = {
+            'variables': utils.json_stringify(variables),
+            'features': utils.json_stringify(features),
+            'fieldToggles': utils.json_stringify(fieldToggles),
+        }
+        return "POST", self.URL_SEARCH, body
 
     def search_place(self, lat=None, long=None, search_term=None):
         params = {

--- a/src/tweety/http.py
+++ b/src/tweety/http.py
@@ -417,6 +417,11 @@ class Request:
 
         keyword = quote(keyword, safe='"()%')
         request_data = self._builder.search(keyword, cursor, filter_)
+        # X migrated SearchTimeline from GET to POST (March 2026).
+        # The builder returns the payload in "params"; move it to "json"
+        # so httpx sends it as a JSON request body instead of query params.
+        if request_data.get("method") == "POST" and "params" in request_data:
+            request_data["json"] = request_data.pop("params")
         response = await self.__get_response__(**request_data)
         return response
 


### PR DESCRIPTION
## Summary

X/Twitter migrated the `SearchTimeline` GraphQL endpoint from `GET` to `POST` around mid-March 2026. `GET` requests now return `404`, which surfaces as `TwitterError: Page not Found. Most likely you need elevated authorization to access this resource`.

This PR fixes the search functionality with two minimal changes:

### Changes

**`builder.py`**
- Update `URL_SEARCH` queryId to current value (`GcXk9vN_d1jUfHNqLacXQA`)
- Change search method to return `"POST"` with a JSON body dict instead of `"GET"` with URL-encoded query params
- Include `fieldToggles` in the POST body (was previously omitted)

**`http.py`**
- In `perform_search()`, detect POST method and move the payload from `params` (query string) to `json` (request body) so httpx sends it correctly

### Testing

Confirmed working with cookie-based auth as of 2026-03-30. Returns 20 tweets per page as expected.

### Related Issues

- Fixes #285 (search returns unrelated posts / no results)
- Fixes #276 (GuestTokenNotFound / Page not Found)

### Context

Multiple projects tracking this same breaking change:
- d60/twikit PR #412 (same GET→POST fix)
- vladkens/twscrape issue #298
- Multiple independent scrapers confirmed POST works where GET returns 404