### PR TITLE
fix: handle None community and add CommunityUnavailable check

### DIFF
--- a/src/tweety/types/twDataTypes.py
+++ b/src/tweety/types/twDataTypes.py
@@ -495,7 +495,17 @@ class Tweet(_TwType):
         return self._tweet.get('rest_id')
 
     def _get_community(self):
-        return Community(self._client, self._tweet.get("author_community_relationship") or self._tweet.get('community_results'))
+        data = self._tweet.get("author_community_relationship") or self._tweet.get('community_results')
+
+        if not data:
+            return None
+
+        community = Community(self._client, data)
+
+        if community is None or not community.available:
+            return None
+        
+        return community
 
     def _get_author(self):
         if self._tweet.get("core"):
@@ -1597,17 +1607,24 @@ class Community(_TwType):
     def __init__(self, client, data, *args, **kwargs):
         self._raw = data
         self._client = client
-        self._community = find_objects(self._raw, "__typename", "Community", recursive=False)
-        self.id = self._get_id()
-        self.date = self.created_at = self._get_date()
-        self.description = self._get_description()
-        self.name = self._get_name()
-        self.role = self._get_role()
-        self.member_count = self._get_member_count()
-        self.moderator_count = self._get_moderator_count()
-        self.admin = self._get_admin()
-        self.creator = self._get_creator()
-        self.rules = self._get_rules()
+        self._community = (
+            find_objects(self._raw, "__typename", "Community", recursive=False) or
+            find_objects(self._raw, "__typename", "CommunityUnavailable", recursive=False)
+        )
+
+        unavailable = (self._community.get('__typename') == 'CommunityUnavailable') if self._community else True
+        self.available = not unavailable
+        if self.available:
+            self.id = self._get_id()
+            self.date = self.created_at = self._get_date()
+            self.description = self._get_description()
+            self.name = self._get_name()
+            self.role = self._get_role()
+            self.member_count = self._get_member_count()
+            self.moderator_count = self._get_moderator_count()
+            self.admin = self._get_admin()
+            self.creator = self._get_creator()
+            self.rules = self._get_rules()
 
     def __repr__(self):
         return "Community(id={}, name={}, role={}, admin={})".format(


### PR DESCRIPTION
## Summary

- Fix `Community` initialization crash when community is unavailable
- Handle `CommunityUnavailable` typename returned by API

## Problem

When a valid post link points to a community that no longer exists, the original `self._tweet.get("author_community_relationship") or self._tweet.get('community_results')` returns `{'result': {'__typename': 'CommunityUnavailable'}}`. However, the initialization of the Community object does not handle this "community unavailable" error, causing `Community._community` to be `None`. This subsequently leads to an `AttributeError` when calling other initialization functions such as `self._get_id()`.
(AttributeError: 'NoneType' object has no attribute 'get')

## Solution

1. **`Tweet._get_community()`**: Check if community data exists and is available before returning
2. **`Community.__init__()`**: 
   - Accept both `Community` and `CommunityUnavailable` typename
   - Add `available` boolean property to indicate community status
   - Only initialize community attributes when community is available

## Behavior

- `tweet.community` returns `None` if community is unavailable or data is missing
- `tweet.community.available` is `False` if community is `CommunityUnavailable`
- If the `community` attribute is valid, `tweet.community.available` will be set to `True`, and other initialization operations will proceed as in the original code.